### PR TITLE
Add session variable to DBSession init

### DIFF
--- a/fastapi_sqlalchemy/middleware.py
+++ b/fastapi_sqlalchemy/middleware.py
@@ -61,6 +61,7 @@ class DBSessionMeta(type):
 
 class DBSession(metaclass=DBSessionMeta):
     def __init__(self, session_args: Dict = None):
+        self.session = None
         self.token = None
         self.session_args = session_args or {}
 


### PR DESCRIPTION
While using db.session on pycharm, it notify `Unresolved attribute reference 'session' for class 'DBSession'` errors.

To avoid it, added `self.session` to DBSession.