### PR TITLE
Fix db type hinting DBSession to DBSessionMeta

### DIFF
--- a/fastapi_sqlalchemy/middleware.py
+++ b/fastapi_sqlalchemy/middleware.py
@@ -79,4 +79,4 @@ class DBSession(metaclass=DBSessionMeta):
         _session.reset(self.token)
 
 
-db: DBSession = DBSession
+db: DBSessionMeta = DBSession


### PR DESCRIPTION
Fix db type hinting DBSession to DBSessionMeta for avoid pycharm error message.