### PR TITLE
add option to automatically commit on exit

### DIFF
--- a/fastapi_sqlalchemy/middleware.py
+++ b/fastapi_sqlalchemy/middleware.py
@@ -77,7 +77,7 @@ class DBSession(metaclass=DBSessionMeta):
         sess = _session.get()
         if exc_type is not None:
             sess.rollback()
-            
+
         if self.commit_on_exit:
             sess.commit()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy import create_engine


### PR DESCRIPTION
Don't know if you're interested, but lots of DB libs I've used have had this option, such that after each request the session is can be automatically committed.